### PR TITLE
[Bug fix] : Remove list as default arguments values from methods

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/src/pyslice/pyslice_lib/PySPG/PyGrace.py
+++ b/src/pyslice/pyslice_lib/PySPG/PyGrace.py
@@ -38,7 +38,8 @@ class GraceDataSet(object):
 
     basfill = {"type": 0, "rule": 0, "color": 1, "pattern": 1}
 
-    def __init__(self, n=0, d=[], gT="xy"):
+    def __init__(self, n=0, d=None, gT="xy"):
+        d = [] if d is None else d
         self.data = d
         self.name = n
 

--- a/src/pyslice/pyslice_lib/PySPG/TeXParser.py
+++ b/src/pyslice/pyslice_lib/PySPG/TeXParser.py
@@ -49,10 +49,11 @@ class TeXParser(ParamParser):
             filter(lambda x: x.strip()[0] in "+*/-.", commands).pop()
         )
 
-    def __tex(self, outname="plots.tex", plotnames=[]):
+    def __tex(self, outname="plots.tex", plotnames=None):
         """
         for the actual values of the iterator self.parser_original, dumps a agr
         """
+        plotnames = [] if plotnames is None else plotnames
         cwd = os.path.abspath(os.path.curdir)
         #
         # Directory where the AGR will be located
@@ -119,9 +120,10 @@ class TeXParser(ParamParser):
 
         os.chdir(cwd)
 
-    def doit(self, outname="plots.tex", plotnames=[]):
+    def doit(self, outname="plots.tex", plotnames=None):
         """
         Suquencially dumps all the plotnames (a list of .agr files)
         """
+        plotnames = [] if plotnames is None else plotnames
         for i in self.parser_original:
             self.__tex(outname, plotnames)


### PR DESCRIPTION
**Issue:** 
- Few methods are using the mutable like list as a default argument value.
- Python’s default arguments are evaluated once when the function is defined, not each time the function is called. This means that if you use a mutable default argument and mutate it, you will and have mutated that object for all future calls to the function as well.
- Read more here: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

**Proposed fix:**
- Remove the mutable default argument value with `None` and add an if condition in the method implementation for default assignement.
